### PR TITLE
Change MaaS plugins output to InfluxDB format

### DIFF
--- a/maas/plugins/ceph_monitoring.py
+++ b/maas/plugins/ceph_monitoring.py
@@ -55,7 +55,7 @@ def get_mon_statistics(client=None, keyring=None, host=None):
         if each['name'] == host:
             health_status = STATUSES[each['health']]
             break
-    maas_common.metric('mon_health', 'uint32', health_status)
+    maas_common.metric('ceph_mon', 'mon_health', health_status)
 
 
 def get_osd_statistics(client=None, keyring=None, osd_ids=None):
@@ -80,7 +80,7 @@ def get_osd_statistics(client=None, keyring=None, osd_ids=None):
                 break
         for key in ('kb', 'kb_used', 'kb_avail'):
             name = '_'.join((osd_ref, key))
-            maas_common.metric(name, 'uint64', osd[key])
+            maas_common.metric('ceph_osd', name, osd[key])
 
 
 def get_cluster_statistics(client=None, keyring=None):
@@ -134,7 +134,7 @@ def get_cluster_statistics(client=None, keyring=None):
 
     # Submit gathered metrics
     for m in metrics:
-        maas_common.metric(m['name'], m['type'], m['value'])
+        maas_common.metric('ceph_culster', m['name'], m['value'])
 
 
 def get_args():
@@ -165,7 +165,6 @@ def main(args):
     if args.subparser_name == 'mon':
         kwargs['host'] = args.host
     get_statistics[args.subparser_name](**kwargs)
-    maas_common.status_ok()
 
 
 if __name__ == '__main__':

--- a/maas/plugins/cinder_api_local_check.py
+++ b/maas/plugins/cinder_api_local_check.py
@@ -23,10 +23,8 @@ import ipaddr
 from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 import requests
 from requests import exceptions as exc
 
@@ -75,24 +73,20 @@ def check(auth_ref, args):
         snap_status_count = collections.Counter(snap_statuses)
         total_snaps = len(snap.json()['snapshots'])
 
-    status_ok()
-    metric_bool('cinder_api_local_status', is_up)
+    metric('cinder_api', 'cinder_api_local_status', str(int(is_up)))
     # only want to send other metrics if api is up
     if is_up:
-        metric('cinder_api_local_response_time',
-               'double',
-               '%.3f' % milliseconds,
-               'ms')
-        metric('total_cinder_volumes', 'uint32', total_vols, 'volumes')
+        metric('cinder_api',
+               'cinder_api_local_response_time',
+               '%.3f' % milliseconds)
+        metric('cinder_api', 'total_cinder_volumes', total_vols)
         for status in VOLUME_STATUSES:
-            metric('cinder_%s_volumes' % status,
-                   'uint32',
-                   vol_status_count[status], 'volumes')
-        metric('total_cinder_snapshots', 'uint32', total_snaps, 'snapshots')
+            metric('cinder_api', 'cinder_%s_volumes' % status,
+                   vol_status_count[status])
+        metric('cinder_api', 'total_cinder_snapshots', total_snaps)
         for status in VOLUME_STATUSES:
-            metric('cinder_%s_snaps' % status,
-                   'uint32',
-                   snap_status_count[status], 'snapshots')
+            metric('cinder_api', 'cinder_%s_snaps' % status,
+                   snap_status_count[status])
 
 
 def main(args):

--- a/maas/plugins/cinder_service_check.py
+++ b/maas/plugins/cinder_service_check.py
@@ -20,10 +20,9 @@ import argparse
 # consideres it third-party
 from maas_common import get_auth_ref
 from maas_common import get_keystone_client
-from maas_common import metric_bool
+from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 import requests
 from requests import exceptions as exc
 
@@ -71,8 +70,6 @@ def check(auth_ref, args):
     if len(services) == 0:
         status_err('No host(s) found in the service list')
 
-    status_ok()
-
     if args.host:
 
         for service in services:
@@ -86,7 +83,7 @@ def check(auth_ref, args):
                 [host, backend] = service['host'].split('@')
                 name = '%s-%s_status' % (service['binary'], backend)
 
-            metric_bool(name, service_is_up)
+            metric('cinder_service', name, str(int(service_is_up)))
     else:
         for service in services:
             service_is_up = True
@@ -94,7 +91,7 @@ def check(auth_ref, args):
                 service_is_up = False
 
             name = '%s_on_host_%s' % (service['binary'], service['host'])
-            metric_bool(name, service_is_up)
+            metric('cinder_service', name, str(int(service_is_up)))
 
 
 def main(args):

--- a/maas/plugins/conntrack_count.py
+++ b/maas/plugins/conntrack_count.py
@@ -55,9 +55,8 @@ def main():
     except maas_common.MaaSException as e:
         maas_common.status_err(str(e))
     else:
-        maas_common.status_ok()
         for name, data in metrics.viewitems():
-            maas_common.metric(name, 'uint32', data['value'])
+            maas_common.metric('contrack', name, data['value'])
 
 
 if __name__ == '__main__':

--- a/maas/plugins/disk_utilisation.py
+++ b/maas/plugins/disk_utilisation.py
@@ -20,7 +20,6 @@ import subprocess
 from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 
 def utilisation(time):
@@ -38,6 +37,5 @@ if __name__ == '__main__':
         except Exception as e:
             status_err(e)
         else:
-            status_ok()
             for util in utils:
-                metric('disk_utilisation_%s' % util[0], 'double', util[1], '%')
+                metric('system', 'disk_utilisation_%s' % util[0], util[1])

--- a/maas/plugins/elasticsearch.py
+++ b/maas/plugins/elasticsearch.py
@@ -22,7 +22,7 @@ import re
 from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
+
 import requests
 
 
@@ -130,9 +130,8 @@ def main():
     num_errors = get_number_of('ERROR', latest)
     num_warnings = get_number_of('WARN*', latest)
 
-    status_ok()
-    metric('NUMBER_OF_LOG_ERRORS', 'uint32', num_errors)
-    metric('NUMBER_OF_LOG_WARNINGS', 'uint32', num_warnings)
+    metric('elasticsearch', 'NUMBER_OF_LOG_ERRORS', num_errors)
+    metric('elasticsearch', 'NUMBER_OF_LOG_WARNINGS', num_warnings)
 
 
 if __name__ == '__main__':

--- a/maas/plugins/galera_check.py
+++ b/maas/plugins/galera_check.py
@@ -21,7 +21,6 @@ import subprocess
 from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 
 def galera_check(arg):
@@ -65,45 +64,45 @@ def parse_args():
 
 
 def print_metrics(replica_status):
-    status_ok()
-    metric('wsrep_replicated_bytes', 'int64',
-           replica_status['wsrep_replicated_bytes'], 'bytes')
-    metric('wsrep_received_bytes', 'int64',
-           replica_status['wsrep_received_bytes'], 'bytes')
-    metric('wsrep_commit_window_size', 'double',
-           replica_status['wsrep_commit_window'], 'sequence_delta')
-    metric('wsrep_cluster_size', 'int64',
-           replica_status['wsrep_cluster_size'], 'nodes')
-    metric('queries_per_second', 'int64',
-           replica_status['Queries'], 'qps')
-    metric('wsrep_cluster_state_uuid', 'string',
+
+    metric('galera', 'wsrep_replicated_bytes',
+           replica_status['wsrep_replicated_bytes'])
+    metric('galera', 'wsrep_received_bytes',
+           replica_status['wsrep_received_bytes'])
+    metric('galera', 'wsrep_commit_window_size',
+           replica_status['wsrep_commit_window'])
+    metric('galera', 'wsrep_cluster_size_nodes',
+           replica_status['wsrep_cluster_size'])
+    metric('galera', 'queries_per_second',
+           replica_status['Queries'])
+    metric('galera', 'wsrep_cluster_state_uuid',
            replica_status['wsrep_cluster_state_uuid'])
-    metric('wsrep_cluster_status', 'string',
+    metric('galera', 'wsrep_cluster_status',
            replica_status['wsrep_cluster_status'])
-    metric('wsrep_local_state_uuid', 'string',
+    metric('galera', 'wsrep_local_state_uuid',
            replica_status['wsrep_local_state_uuid'])
-    metric('wsrep_local_state_comment', 'string',
+    metric('galera', 'wsrep_local_state_comment',
            replica_status['wsrep_local_state_comment'])
-    metric('mysql_max_configured_connections', 'int64',
-           replica_status['max_connections'], 'connections')
-    metric('mysql_current_connections', 'int64',
-           replica_status['Threads_connected'], 'connections')
-    metric('mysql_max_seen_connections', 'int64',
-           replica_status['Max_used_connections'], 'connections')
-    metric('num_of_open_files', 'int64',
-           replica_status['Open_files'], 'files')
-    metric('open_files_limit', 'int64',
-           replica_status['open_files_limit'], 'files')
-    metric('innodb_row_lock_time_avg', 'int64',
-           replica_status['Innodb_row_lock_time_avg'], 'milliseconds')
-    metric('innodb_deadlocks', 'int64',
-           replica_status['Innodb_deadlocks'], 'deadlocks')
-    metric('access_denied_errors', 'int64',
-           replica_status['Access_denied_errors'], 'access_denied_errors')
-    metric('aborted_clients', 'int64',
-           replica_status['Aborted_clients'], 'aborted_clients')
-    metric('aborted_connects', 'int64',
-           replica_status['Aborted_connects'], 'aborted_connects')
+    metric('galera', 'mysql_max_configured_connections',
+           replica_status['max_connections'])
+    metric('galera', 'mysql_current_connections',
+           replica_status['Threads_connected'])
+    metric('galera', 'mysql_max_seen_connections',
+           replica_status['Max_used_connections'])
+    metric('galera', 'num_of_open_files',
+           replica_status['Open_files'])
+    metric('galera', 'open_files_limit',
+           replica_status['open_files_limit'])
+    metric('galera', 'innodb_row_lock_time_avg',
+           replica_status['Innodb_row_lock_time_avg'])
+    metric('galera', 'innodb_deadlocks',
+           replica_status['Innodb_deadlocks'])
+    metric('galera', 'access_denied_errors',
+           replica_status['Access_denied_errors'])
+    metric('galera', 'aborted_clients',
+           replica_status['Aborted_clients'])
+    metric('galera', 'aborted_connects',
+           replica_status['Aborted_connects'])
 
 
 def main():

--- a/maas/plugins/glance_api_local_check.py
+++ b/maas/plugins/glance_api_local_check.py
@@ -23,10 +23,8 @@ from glanceclient import exc as exc
 from maas_common import get_auth_ref
 from maas_common import get_glance_client
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 
 IMAGE_STATUSES = ['active', 'queued', 'killed']
@@ -59,20 +57,15 @@ def check(auth_ref, args):
         images = glance.images.list(search_opts={'all_tenants': 1})
         status_count = collections.Counter([s.status for s in images])
 
-    status_ok()
-    metric_bool('glance_api_local_status', is_up)
+    metric('glance_api', 'glance_api_local_status', str(int(is_up)))
 
     # only want to send other metrics if api is up
     if is_up:
-        metric('glance_api_local_response_time',
-               'double',
-               '%.3f' % milliseconds,
-               'ms')
+        metric('glance_api', 'glance_api_local_response_time',
+               '%.3f' % milliseconds)
         for status in IMAGE_STATUSES:
-            metric('glance_%s_images' % status,
-                   'uint32',
-                   status_count[status],
-                   'images')
+            metric('glance_api', 'glance_%s_images' % status,
+                   status_count[status])
 
 
 def main(args):

--- a/maas/plugins/glance_registry_local_check.py
+++ b/maas/plugins/glance_registry_local_check.py
@@ -20,10 +20,8 @@ import ipaddr
 from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 import requests
 from requests import exceptions as exc
 
@@ -50,13 +48,13 @@ def check(auth_ref, args):
     except Exception as e:
         status_err(str(e))
 
-    status_ok()
-    metric_bool('glance_registry_local_status', is_up)
+    metric('glance_registry', 'glance_registry_local_status', str(int(is_up)))
     # only want to send other metrics if api is up
     if is_up:
         milliseconds = r.elapsed.total_seconds() * 1000
-        metric('glance_registry_local_response_time', 'double',
-               '%.3f' % milliseconds, 'ms')
+        metric('glance_registry',
+               'glance_registry_local_response_time',
+               '%.3f' % milliseconds)
 
 
 def main(args):

--- a/maas/plugins/heat_api_local_check.py
+++ b/maas/plugins/heat_api_local_check.py
@@ -23,10 +23,8 @@ from maas_common import get_auth_ref
 from maas_common import get_heat_client
 from maas_common import get_keystone_client
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 
 def check(auth_ref, args):
@@ -55,14 +53,12 @@ def check(auth_ref, args):
         end = time.time()
         milliseconds = (end - start) * 1000
 
-    status_ok()
-    metric_bool('heat_api_local_status', is_up)
+    metric('heat_api', 'heat_api_local_status', str(int(is_up)))
     if is_up:
         # only want to send other metrics if api is up
-        metric('heat_api_local_response_time',
-               'double',
-               '%.3f' % milliseconds,
-               'ms')
+        metric('heat_api',
+               'heat_api_local_response_time',
+               '%.3f' % milliseconds)
 
 
 def main(args):

--- a/maas/plugins/horizon_check.py
+++ b/maas/plugins/horizon_check.py
@@ -21,10 +21,8 @@ import ipaddr
 from lxml import html
 from maas_common import get_auth_details
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 import requests
 from requests import exceptions as exc
 
@@ -97,14 +95,13 @@ def check(args):
         login_status_code = l.status_code
         login_milliseconds = l.elapsed.total_seconds() * 1000
 
-    status_ok()
-    metric_bool('horizon_local_status', is_up)
+    metric('horizon', 'horizon_local_status', str(int(is_up)))
 
     if is_up:
-        metric('splash_status_code', 'uint32', splash_status_code, 'http_code')
-        metric('splash_milliseconds', 'double', splash_milliseconds, 'ms')
-        metric('login_status_code', 'uint32', login_status_code, 'http_code')
-        metric('login_milliseconds', 'double', login_milliseconds, 'ms')
+        metric('horizon', 'splash_status_http_code', splash_status_code)
+        metric('horizon', 'splash_milliseconds', splash_milliseconds)
+        metric('horizon', 'login_status_http_code', login_status_code)
+        metric('horizon', 'login_milliseconds', login_milliseconds)
 
 
 def main(args):

--- a/maas/plugins/hp_monitoring.py
+++ b/maas/plugins/hp_monitoring.py
@@ -77,9 +77,8 @@ def main():
     status['hardware_controller_battery_status'] = \
         get_controller_battery_status()
 
-    maas_common.status_ok()
     for name, value in status.viewitems():
-        maas_common.metric_bool(name, value)
+        maas_common.metric('hp_monitoring', name, str(int(value)))
 
 
 if __name__ == '__main__':

--- a/maas/plugins/keystone_api_local_check.py
+++ b/maas/plugins/keystone_api_local_check.py
@@ -22,10 +22,8 @@ from keystoneclient.openstack.common.apiclient import exceptions as exc
 from maas_common import get_auth_details
 from maas_common import get_keystone_client
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 
 def check(args, auth_details):
@@ -62,16 +60,14 @@ def check(args, auth_details):
             project_count = len(keystone.projects.list())
             user_count = len(keystone.users.list(domain='Default'))
 
-    status_ok()
-    metric_bool('keystone_api_local_status', is_up)
+    metric('keystone_api', 'keystone_api_local_status', str(int(is_up)))
     # only want to send other metrics if api is up
     if is_up:
-        metric('keystone_api_local_response_time',
-               'double',
-               '%.3f' % milliseconds,
-               'ms')
-        metric('keystone_user_count', 'uint32', user_count, 'users')
-        metric('keystone_tenant_count', 'uint32', project_count, 'tenants')
+        metric('keystone_api',
+               'keystone_api_local_response_time',
+               '%.3f' % milliseconds)
+        metric('keystone_api', 'keystone_user_count', user_count)
+        metric('keystone_api', 'keystone_tenant_count', project_count)
 
 
 def main(args):

--- a/maas/plugins/maas_common.py
+++ b/maas/plugins/maas_common.py
@@ -529,11 +529,11 @@ def status_ok(message=None, force_print=False):
 METRICS = []
 
 
-def metric(name, metric_type, value, unit=None):
+def metric(service, name, value, unit=None):
     global METRICS
     if len(METRICS) > 49:
         status_err('Maximum of 50 metrics per check')
-    metric_line = 'metric %s %s %s' % (name, metric_type, value)
+    metric_line = '%s %s=%s' % (service, name, value)
     if unit is not None:
         metric_line = ' '.join((metric_line, unit))
     metric_line = metric_line.replace('\n', '\\n')

--- a/maas/plugins/memcached_status.py
+++ b/maas/plugins/memcached_status.py
@@ -19,10 +19,8 @@ import re
 
 import ipaddr
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 import memcache
 
 
@@ -65,11 +63,10 @@ def main(args):
                        'of memcached, and you are using version %s'
                        % (VERSIONS, current_version))
 
-    status_ok()
-    metric_bool('memcache_api_local_status', is_up)
+    metric('memcached', 'memcache_api_local_status', str(int(is_up)))
     if is_up:
         for m, u in MEMCACHE_METRICS.iteritems():
-            metric('memcache_%s' % m, 'uint64', stats[m], u)
+            metric('memcached', 'memcache_%s' % m, stats[m])
 
 
 if __name__ == '__main__':

--- a/maas/plugins/neutron_api_local_check.py
+++ b/maas/plugins/neutron_api_local_check.py
@@ -20,10 +20,8 @@ import time
 import ipaddr
 from maas_common import get_neutron_client
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 from neutronclient.client import exceptions as exc
 
 
@@ -58,18 +56,15 @@ def check(args):
         routers = len(neutron.list_routers()['routers'])
         subnets = len(neutron.list_subnets()['subnets'])
 
-    status_ok()
-    metric_bool('neutron_api_local_status', is_up)
+    metric('neutron_api', 'neutron_api_local_status', str(int(is_up)))
     # only want to send other metrics if api is up
     if is_up:
-        metric('neutron_api_local_response_time',
-               'double',
-               '%.3f' % milliseconds,
-               'ms')
-        metric('neutron_networks', 'uint32', networks, 'networks')
-        metric('neutron_agents', 'uint32', agents, 'agents')
-        metric('neutron_routers', 'uint32', routers, 'agents')
-        metric('neutron_subnets', 'uint32', subnets, 'subnets')
+        metric('neutron_api', 'neutron_api_local_response_time',
+               '%.3f' % milliseconds)
+        metric('neutron_api', 'neutron_networks', networks)
+        metric('neutron_api', 'neutron_agents', agents)
+        metric('neutron_api', 'neutron_routers_agents', routers)
+        metric('neutron_api', 'neutron_subnets', subnets)
 
 
 def main(args):

--- a/maas/plugins/neutron_metadata_local_check.py
+++ b/maas/plugins/neutron_metadata_local_check.py
@@ -19,10 +19,9 @@ import shlex
 import subprocess
 
 from maas_common import get_neutron_client
-from maas_common import metric_bool
+from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 # identify the first active neutron agents container on this host
 # network namespaces can only be accessed from within neutron agents container
@@ -67,11 +66,11 @@ def check(args):
                 failures.append(net_id)
 
     is_ok = len(failures) == 0
-    metric_bool('neutron-metadata-agent-proxy_status', is_ok)
+    metric('neutron_metadata',
+           'neutron-metadata-agent-proxy_status', str(int(is_ok)))
 
-    if is_ok:
-        status_ok()
-    else:
+    if not is_ok:
+        metric('neutron_metadata', 'status', 0)
         status_err('neutron metadata agent proxies fail on host %s '
                    'net_ids: %s' % (container, ','.join(failures)))
 

--- a/maas/plugins/neutron_service_check.py
+++ b/maas/plugins/neutron_service_check.py
@@ -17,10 +17,9 @@
 import argparse
 
 from maas_common import get_neutron_client
-from maas_common import metric_bool
+from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 
 def check(args):
@@ -43,7 +42,6 @@ def check(args):
         status_err("No host(s) found in the agents list")
 
     # return all the things
-    status_ok()
     for agent in agents:
         agent_is_up = True
         if agent['admin_state_up'] and not agent['alive']:
@@ -56,7 +54,7 @@ def check(args):
                                          agent['id'],
                                          agent['host'])
 
-        metric_bool(name, agent_is_up)
+        metric('neutron_service', name, str(int(agent_is_up)))
 
 
 def main(args):

--- a/maas/plugins/nova_api_local_check.py
+++ b/maas/plugins/nova_api_local_check.py
@@ -23,10 +23,8 @@ from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import get_nova_client
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 from novaclient.client import exceptions as exc
 
 SERVER_STATUSES = ['ACTIVE', 'STOPPED', 'ERROR']
@@ -64,18 +62,14 @@ def check(auth_ref, args):
         # gather some metrics
         status_count = collections.Counter([s.status for s in servers])
 
-    status_ok()
-    metric_bool('nova_api_local_status', is_up)
+    metric('nova_api', 'nova_api_local_status', str(int(is_up)))
     # only want to send other metrics if api is up
     if is_up:
-        metric('nova_api_local_response_time',
-               'double',
-               '%.3f' % milliseconds,
-               'ms')
+        metric('nova_api', 'nova_api_local_response_time',
+               '%.3f' % milliseconds)
         for status in SERVER_STATUSES:
-            metric('nova_instances_in_state_%s' % status,
-                   'uint32',
-                   status_count[status], 'instances')
+            metric('nova_api', 'nova_instances_in_state_%s' % status,
+                   status_count[status])
 
 
 def main(args):

--- a/maas/plugins/nova_api_metadata_local_check.py
+++ b/maas/plugins/nova_api_metadata_local_check.py
@@ -18,10 +18,8 @@ import argparse
 
 import ipaddr
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 import requests
 from requests import exceptions as exc
 
@@ -46,14 +44,13 @@ def check(args):
     except Exception as e:
         status_err(str(e))
 
-    status_ok()
-    metric_bool('nova_api_metadata_local_status', is_up)
+    metric('nova_api_metadata',
+           'nova_api_metadata_local_status', str(int(is_up)))
     # only want to send other metrics if api is up
     if is_up:
-        metric('nova_api_metadata_local_response_time',
-               'double',
-               '%.3f' % milliseconds,
-               'ms')
+        metric('nova_api_metadata',
+               'nova_api_metadata_local_response_time',
+               '%.3f' % milliseconds)
 
 
 def main(args):

--- a/maas/plugins/nova_cloud_stats.py
+++ b/maas/plugins/nova_cloud_stats.py
@@ -24,7 +24,6 @@ from maas_common import get_nova_client
 from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 # The actual stat names from novaclient are nasty, so this mapping is used to
 # translate them to something more consistent and usable, as well as set the
@@ -94,12 +93,11 @@ def check(auth_ref, args):
             cloud_stats[metric_name]['type'] = \
                 vals['type']
 
-    status_ok()
     for metric_name in cloud_stats.iterkeys():
-        metric('cloud_resource_%s' % metric_name,
-               cloud_stats[metric_name]['type'],
-               cloud_stats[metric_name]['value'],
-               cloud_stats[metric_name]['unit'])
+        metric('nova_cloud_stats'
+               'cloud_resource_%s_%s' % (metric_name,
+                                         cloud_stats[metric_name]['unit'], ),
+               cloud_stats[metric_name]['value'])
 
 
 def main(args):

--- a/maas/plugins/nova_service_check.py
+++ b/maas/plugins/nova_service_check.py
@@ -19,10 +19,9 @@ import argparse
 from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import get_nova_client
-from maas_common import metric_bool
+from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 
 def check(auth_ref, args):
@@ -52,7 +51,6 @@ def check(auth_ref, args):
         status_err("No host(s) found in the service list")
 
     # return all the things
-    status_ok()
     for service in services:
         service_is_up = True
 
@@ -64,7 +62,7 @@ def check(auth_ref, args):
         else:
             name = '%s_on_host_%s_status' % (service.binary, service.host)
 
-        metric_bool(name, service_is_up)
+        metric('nova_service', name, str(int(service_is_up)))
 
 
 def main(args):

--- a/maas/plugins/openmanage.py
+++ b/maas/plugins/openmanage.py
@@ -18,10 +18,10 @@ import re
 import subprocess
 import sys
 
-from maas_common import metric_bool
+from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
+
 
 SUPPORTED_VERSIONS = set(["7.1.0", "7.4.0"])
 OM_PATTERN = '(?:%(field)s)\s+:\s+(%(group_pattern)s)'
@@ -99,9 +99,8 @@ def main():
     except (OSError, subprocess.CalledProcessError) as e:
         status_err(str(e))
 
-    status_ok()
-    metric_bool('hardware_%s_status' % report_request,
-                all_okay(report, regex[report_type]))
+    metric('openmanage', 'hardware_%s_status' % report_request,
+           str(int(all_okay(report, regex[report_type]))))
 
 
 if __name__ == '__main__':

--- a/maas/plugins/process_check.py
+++ b/maas/plugins/process_check.py
@@ -16,10 +16,9 @@
 import argparse
 import os
 
-from maas_common import metric_bool
+from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 
 def get_process_name(pid):
@@ -88,14 +87,11 @@ def check_process_running(process_names, container_name=None):
         # Unable to get a list of process names for the container or host.
         status_err('Could not get a list of running processes')
 
-    # Since we've fetched a process list, report status_ok.
-    status_ok()
-
     # Report the presence of each process from the command line in the
     # running process list for the host or specified container.
     for process_name in process_names:
-        metric_bool('%s_process_status' % process_name,
-                    process_name in procs)
+        metric('process_check', '%s_process_status' % process_name,
+               str(int(process_name in procs)))
 
 
 def main(args):

--- a/maas/plugins/rabbitmq_status.py
+++ b/maas/plugins/rabbitmq_status.py
@@ -19,10 +19,9 @@ import optparse
 import subprocess
 
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
+
 import requests
 
 OVERVIEW_URL = "http://%s:%s/api/overview"
@@ -183,13 +182,15 @@ def main():
                       options.name)
     _get_queue_metrics(session, metrics, options.host, options.port)
 
-    status_ok()
-
     for k, v in metrics.items():
         if v['value'] is True or v['value'] is False:
-            metric_bool('rabbitmq_%s_status' % k, not v['value'])
+            metric('rabbitmq',
+                   'rabbitmq_%s_status' % k,
+                   str(int(not v['value'])))
         else:
-            metric('rabbitmq_%s' % k, 'int64', v['value'], v['unit'])
+            metric('rabbitmq',
+                   'rabbitmq_%s' % k,
+                   v['value'], v['unit'])
 
 
 if __name__ == "__main__":

--- a/maas/plugins/service_api_local_check.py
+++ b/maas/plugins/service_api_local_check.py
@@ -20,9 +20,7 @@ import ipaddr
 from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import metric
-from maas_common import metric_bool
 from maas_common import print_output
-from maas_common import status_ok
 import requests
 from requests import exceptions as exc
 
@@ -62,15 +60,15 @@ def check(args):
     else:
         up = True
 
-    status_ok()
-    metric_bool('{name}_api_local_status'.format(name=args.name), up)
+    metric('{name}_api'.format(name=args.name),
+           '{name}_api_local_status'.format(name=args.name),
+           str(int(up)))
 
     if up and r.ok:
         milliseconds = r.elapsed.total_seconds() * 1000
-        metric('{name}_api_local_response_time'.format(name=args.name),
-               'double',
-               '%.3f' % milliseconds,
-               'ms')
+        metric('{name}_api'.format(name=args.name),
+               '{name}_api_local_response_time'.format(name=args.name),
+               '%.3f' % milliseconds,)
 
 
 def main(args):

--- a/maas/plugins/swift-dispersion.py
+++ b/maas/plugins/swift-dispersion.py
@@ -66,15 +66,10 @@ def print_metrics(report_for, match):
             # and "partition_copies" groups end up in the dictionary with
             # value None so we need to ignore them when they are found.
             continue
-        if k.endswith('percent'):
-            metric_type = 'double'
-        else:
-            metric_type = 'uint64'
 
-        # Add units when we can
-        unit = 's' if k == 'seconds' else None
-        maas_common.metric('{0}_{1}'.format(report_for, k), metric_type, v,
-                           unit)
+        maas_common.metric('swift_dispersion',
+                           '{0}_{1}'.format(report_for, k),
+                           v)
 
 
 def main():
@@ -100,7 +95,6 @@ def main():
     if not (object_match and container_match):
         maas_common.status_err('Could not parse dispersion report output')
 
-    maas_common.status_ok()
     print_metrics('object', object_match)
     print_metrics('container', container_match)
 

--- a/maas/plugins/swift-recon.py
+++ b/maas/plugins/swift-recon.py
@@ -322,11 +322,13 @@ def print_nested_stats(statistics):
 
 
 metrics_per_stat = {
-    'avg': lambda name, val: maas_common.metric(name, 'double', val),
-    'failed': lambda name, val: maas_common.metric(name, 'double', val[:-1])
+    'avg': lambda name, val: maas_common.metric('swift_recon', name, val),
+    'failed': lambda name, val: maas_common.metric('swift_recon',
+                                                   name,
+                                                   val[:-1])
 }
 
-DEFAULT_METRIC = lambda name, val: maas_common.metric(name, 'uint64', val)
+DEFAULT_METRIC = lambda name, val: maas_common.metric('swift_recon', name, val)
 
 
 def print_stats(prefix, statistics):
@@ -335,7 +337,7 @@ def print_stats(prefix, statistics):
     """
     for name, value in statistics.items():
         metric = metrics_per_stat.get(name, DEFAULT_METRIC)
-        metric('{0}_{1}'.format(prefix, name), value)
+        metric('swift_recon', '{0}_{1}'.format(prefix, name), value)
 
 
 def make_parser():
@@ -380,7 +382,6 @@ def main():
         maas_common.status_err(str(e))
 
     if stats:
-        maas_common.status_ok()
         print_nested_stats(stats)
 
 

--- a/maas/plugins/vg_check.py
+++ b/maas/plugins/vg_check.py
@@ -21,7 +21,6 @@ import subprocess
 from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
-from maas_common import status_ok
 
 
 def run_command(arg):
@@ -44,13 +43,10 @@ def parse_args():
 
 
 def print_metrics(sizes, vgname):
-    status_ok()
-    metric('%s_vg_total_space' % vgname, 'int64',
-           sizes['totalsize'], 'Megabytes')
-    metric('%s_vg_free_space' % vgname, 'int64',
-           sizes['free'], 'Megabytes')
-    metric('%s_vg_used_space' % vgname, 'int64',
-           sizes['used'], 'Megabytes')
+    metric('volume_group', 'name', vgname)
+    metric('volume_group', 'vg_total_megabytes_space', sizes['totalsize'])
+    metric('volume_group', 'vg_free_megabytes_space', sizes['free'])
+    metric('volume_group', 'vg_used_megabytes_space', sizes['used'])
 
 
 def main():


### PR DESCRIPTION
This is a first and maybe "dirty" approach to change the
MaaS plugins output to match InfluxDB data format so
telegraf can pick the output and send it to influxdb.